### PR TITLE
Aggiunta long-options

### DIFF
--- a/laboratorio_6cfu/code/include/ordinamento.hh
+++ b/laboratorio_6cfu/code/include/ordinamento.hh
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <string>
 #include <unistd.h>
-
+#include <getopt.h>
 struct Stat {
 	int ct_swap;
 	int ct_cmp;

--- a/laboratorio_6cfu/code/src/merge.cpp
+++ b/laboratorio_6cfu/code/src/merge.cpp
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
                 cmp_max = ct_cmp;
         }
 
-        cout << (long)(n*(long)(log(n)/log(2)) + 2*( n-pow(2,(long)(log(n)/log(2))) )) << endl;
+        // cout << (long)(n*(long)(log(n)/log(2)) + 2*( n-pow(2,(long)(log(n)/log(2))) )) << endl;
 
         if (ndiv > 1)
             cout << n << "," << ntests << "," << swap_min << "," << (0.0 + swap_avg) / ntests << "," << swap_max << "," << 0.0 << "," << cmp_min << "," << (0.0 + cmp_avg) / ntests << "," << cmp_max << "," << n * log(n) / log(2) << "\n";

--- a/laboratorio_6cfu/code/src/ordinamento.cpp
+++ b/laboratorio_6cfu/code/src/ordinamento.cpp
@@ -2,9 +2,10 @@
 
 void print_usage(char **argv) {
 	using std::cerr;
+	using std::endl;
 
     cerr << "Usage: " << argv[0] << " max-dim [Options]\n";
-        cerr << "   max-dim: specifica la massima dimensione n del problema\n";
+        cerr << "   max-dim: specifica la massima dimensione del problema\n";
         cerr << "Options:\n";
         cerr << "  -d=<int>: Specifica quali dimensioni n del problema vengono lanciate in sequenza [default: 1] \n";
         cerr << "            n = k * max-dim / d, k=1 .. d\n";
@@ -13,7 +14,7 @@ void print_usage(char **argv) {
         cerr << "  -v, --verbose: Abilita stampe durante l'esecuzione dell'algoritmo\n";
         cerr << "  -g, --graph: creazione file di dot con il grafo dell'esecuzione (forza d=1 t=1)\n";
         cerr << "  -c, --comparison: (quicksort) compara la partition a tre vie classica con un'altra\n";
-        cerr << "  -o, --output-file: specifica un path per il file di dot\n";
+        cerr << "  -o, --output-file=<path-to-file>: specifica un path per il file .dot" << endl;
 }
 
 
@@ -59,7 +60,12 @@ int parse_cmd(int argc, char **argv, Stat& s) {
             print_usage(argv);
             return 1;
         case '?':
-            std::cerr << "Unknown option -" << (char)optopt << std::endl;
+            std::cerr << "Unknown option";
+            if (optopt)
+                std::cerr << " -" << (char)optopt << std::endl;
+            else
+                std::cerr << std::endl;
+
             print_usage(argv);
             return 1;
         default:
@@ -67,48 +73,12 @@ int parse_cmd(int argc, char **argv, Stat& s) {
         }
     }
 
-    /* 
-    while ((c = getopt(argc, argv, ":d:t:o:vgc")) != -1) {
-        switch (c) {
-        case 'v':
-            s.details = true;
-            break;
-        case 'c':
-            s.comparison = true;
-            break;
-        case 'g':
-            s.graph = 1;
-            s.ndiv = 1;
-            s.ntests = 1;
-            break;
-        case 'd':
-            s.ndiv = atoi(optarg);
-            break;
-        case 't':
-            s.ntests = atoi(optarg);
-            break;
-        case 'o':
-            s.output_path = std::string(optarg);
-            break;
-        case ':':
-            std::cerr << "Option -" << (char)optopt << " needs an argument." << std::endl;
-            print_usage(argv);
-            return 1;
-        case '?':
-            std::cerr << "Unknown option -" << (char)optopt << std::endl;
-            print_usage(argv);
-            return 1;
-        default:
-            break;
-        }
-    }
-
-	s.max_dim = atoi(argv[optind]); 
-    */
     if (optind == argc-1) {
 	    s.max_dim = atoi(argv[optind++]); 
-    } else
+    } else {
         print_usage(argv);
+        return 1;
+    }
 
     if (s.ndiv > s.max_dim) {
         std::cerr << "-d argument must be less or equal to max-dim" << std::endl;

--- a/laboratorio_6cfu/code/src/ordinamento.cpp
+++ b/laboratorio_6cfu/code/src/ordinamento.cpp
@@ -10,10 +10,10 @@ void print_usage(char **argv) {
         cerr << "            n = k * max-dim / d, k=1 .. d\n";
         cerr << "  -t=<int>: Specifica quanti volte viene lanciato l'algoritmo per una specifica dimensione n [default: 1]\n";
         cerr << "            Utile nel caso in cui l'input viene inizializzato in modo random\n";
-        cerr << "  -v [verbose]: Abilita stampe durante l'esecuzione dell'algoritmo\n";
-        cerr << "  -g [graph]: creazione file di dot con il grafo dell'esecuzione (forza d=1 t=1)\n";
-        cerr << "  -c [comparison]: (quicksort) compara la partition a tre vie classica con un'altra\n";
-        cerr << "  -o=[outputh path]: specifica un path per il file di dot\n";
+        cerr << "  -v, --verbose: Abilita stampe durante l'esecuzione dell'algoritmo\n";
+        cerr << "  -g, --graph: creazione file di dot con il grafo dell'esecuzione (forza d=1 t=1)\n";
+        cerr << "  -c, --comparison: (quicksort) compara la partition a tre vie classica con un'altra\n";
+        cerr << "  -o, --output-file: specifica un path per il file di dot\n";
 }
 
 
@@ -23,7 +23,51 @@ int parse_cmd(int argc, char **argv, Stat& s) {
         return 1;
     }
 
+    int option_index = 0;
+    static struct option long_options[] = {
+        {"graph"        , no_argument       , 0,    'g'},
+        {"verbose"      , no_argument       , 0,    'v'},
+        {"comparison"   , no_argument       , 0,    'c'},
+        {"output-file"  , required_argument , 0,    'o'}
+    };
+
     int c;
+    while ((c = getopt_long(argc, argv, ":d:t:o:vgc", long_options, &option_index)) != -1) {
+        switch (c) {
+        case 'v':
+            s.details = true;
+            break;
+        case 'c':
+            s.comparison = true;
+            break;
+        case 'g':
+            s.graph = 1;
+            s.ndiv = 1;
+            s.ntests = 1;
+            break;
+        case 'd':
+            s.ndiv = atoi(optarg);
+            break;
+        case 't':
+            s.ntests = atoi(optarg);
+            break;
+        case 'o':
+            s.output_path = std::string(optarg);
+            break;
+        case ':':
+            std::cerr << "Option -" << (char)optopt << " needs an argument." << std::endl;
+            print_usage(argv);
+            return 1;
+        case '?':
+            std::cerr << "Unknown option -" << (char)optopt << std::endl;
+            print_usage(argv);
+            return 1;
+        default:
+            break;
+        }
+    }
+
+    /* 
     while ((c = getopt(argc, argv, ":d:t:o:vgc")) != -1) {
         switch (c) {
         case 'v':
@@ -59,7 +103,12 @@ int parse_cmd(int argc, char **argv, Stat& s) {
         }
     }
 
-	s.max_dim = atoi(argv[optind]);
+	s.max_dim = atoi(argv[optind]); 
+    */
+    if (optind == argc-1) {
+	    s.max_dim = atoi(argv[optind++]); 
+    } else
+        print_usage(argv);
 
     if (s.ndiv > s.max_dim) {
         std::cerr << "-d argument must be less or equal to max-dim" << std::endl;


### PR DESCRIPTION
Aggiunta di opzioni passate come argomento tramite la funzione `getopt_long()` per garantire compatibilità con macOS.
> L'implementazione di `getopt()` in macOS segue gli standard POSIX e non supporta le aggiunte GNU (permutazione degli argomenti che non sono un'opzione alla fine di `argv`).